### PR TITLE
김준형 Seminar3 과제

### DIFF
--- a/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/seminar/api/SeminarControllerTest.kt
+++ b/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/seminar/api/SeminarControllerTest.kt
@@ -1,0 +1,284 @@
+package com.wafflestudio.seminar.core.seminar.api
+
+import com.wafflestudio.seminar.core.mappingTable.InstructorProfile
+import com.wafflestudio.seminar.core.mappingTable.ParticipantProfile
+import com.wafflestudio.seminar.core.seminar.api.request.EditSeminarRequest
+import com.wafflestudio.seminar.core.seminar.api.request.JoinSeminarRequest
+import com.wafflestudio.seminar.core.seminar.api.request.SeminarMakeRequest
+import com.wafflestudio.seminar.core.seminar.api.response.CountSeminarResponse
+import com.wafflestudio.seminar.core.seminar.api.response.SeminarResponse
+import com.wafflestudio.seminar.core.seminar.repository.SeminarRepository
+import com.wafflestudio.seminar.core.seminar.repository.UserSeminarRepository
+import com.wafflestudio.seminar.core.seminar.service.SeminarService
+import com.wafflestudio.seminar.core.user.Role
+import com.wafflestudio.seminar.core.user.repository.UserEntity
+import com.wafflestudio.seminar.core.user.repository.UserRepository
+import com.wafflestudio.seminar.global.HibernateQueryCounter
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+
+@SpringBootTest
+internal class SeminarControllerTest @Autowired constructor(
+    private val seminarController: SeminarController,
+    private val seminarService: SeminarService,
+    private val userRepository: UserRepository,
+    private val userSeminarRepository: UserSeminarRepository,
+    private val seminarRepository: SeminarRepository,
+    private val hibernateQueryCounter: HibernateQueryCounter
+) {
+
+    @BeforeEach
+    fun refresh() {
+        userRepository.deleteAll()
+        seminarRepository.deleteAll()
+    }
+
+    @Test
+    fun 세미나_만들기() {
+        //given
+        val user = createInstructor("a@naver.com")
+        val seminarMakeRequest = createSeminarMakeRequest("Spring")
+
+        //when
+        var seminarId = 0L
+        val queryCount = hibernateQueryCounter.count {
+            seminarId = seminarController.makeSeminar(user, seminarMakeRequest).id!!
+        }.queryCount
+
+        //then
+        val seminar = seminarRepository.findByIdOrNull(seminarId) ?: fail("Creating seminar failed")
+        assertThat(seminar.name).isEqualTo(seminarMakeRequest.name)
+        assertThat(seminar.capacity).isEqualTo(seminarMakeRequest.capacity)
+        assertThat(seminar.count).isEqualTo(seminarMakeRequest.count)
+        assertThat(seminar.time).isEqualTo(seminarMakeRequest.time)
+        assertThat(seminar.online).isEqualTo(seminarMakeRequest.online)
+        val userSeminar = userSeminarRepository.findByUserEntityAndSeminar(user, seminar).get()
+        assertThat(userSeminar.role).isEqualTo(Role.Instructor)
+
+        //기존에 instructing 하는 세미나가 있는지 조회 쿼리 1
+        //userSeminarRepository, seminarRepository 저장 쿼리 2
+        assertThat(queryCount).isEqualTo(3)
+    }
+
+    @Test
+    fun 세미나_수정() {
+        //given
+        val user = createInstructor("a@naver.com")
+        seminarService.makeSeminar(user, createSeminarMakeRequest("Spring"))
+        val editSeminarRequest = EditSeminarRequest("New name", 123, 8)
+
+        //when
+        var seminarId = 0L
+        val queryCount = hibernateQueryCounter.count {
+            seminarId = seminarController.editSeminar(user, editSeminarRequest).id!!
+        }.queryCount
+
+        //then
+        val seminar = seminarRepository.findById(seminarId).get()
+        assertThat(seminar.name).isEqualTo(editSeminarRequest.name)
+        assertThat(seminar.count).isEqualTo(editSeminarRequest.count)
+        assertThat(seminar.capacity).isEqualTo(editSeminarRequest.capacity)
+        assertThat(seminar.online).isEqualTo(editSeminarRequest.online)
+
+        //수정가능한 세미나 있는지 조회 쿼리 1
+        //세미나 업데이트 쿼리 1
+        assertThat(queryCount).isEqualTo(2)
+    }
+
+    @Test
+    fun 세미나_하나_불러오기() {
+        //given
+        val instructor = createInstructor("b@naver.com")
+        val seminar = seminarService.makeSeminar(instructor, createSeminarMakeRequest("Spring"))
+
+        //when
+
+        //단순초기화
+        var seminarResponse = seminar
+
+        val queryCount = hibernateQueryCounter.count {
+            seminarResponse = seminarController.getSeminarById(seminar.id!!)
+        }.queryCount
+
+        //then
+        val seminarFound = seminarRepository.findById(seminar.id!!).get()
+        assertThat(seminarResponse.capacity).isEqualTo(seminarFound.capacity)
+        assertThat(seminarResponse.name).isEqualTo(seminarFound.name)
+        assertThat(seminarResponse.count).isEqualTo(seminarFound.count)
+        assertThat(seminarResponse.time).isEqualTo(seminarFound.time)
+        assertThat(seminarResponse.online).isEqualTo(seminarFound.online)
+
+        //세미나 조회 쿼리 1
+        assertThat(queryCount).isEqualTo(1)
+    }
+
+    @Test
+    fun 키워드로_세미나_불러오기() {
+        //given
+        createSeminars()
+
+        //when
+        var seminarList = listOf<CountSeminarResponse>()
+        val queryCount = hibernateQueryCounter.count {
+            seminarList = seminarController.getSeminarByQuery("1", "")
+        }.queryCount
+
+        //then
+        for (seminar in seminarList) {
+            assertThat(seminar.name).contains("1")
+        }
+
+        //세미나 조회 쿼리 1
+        assertThat(queryCount).isEqualTo(1)
+    }
+
+    @Test
+    fun 오래된순으로_세미나_불러오기() {
+        //given
+        createSeminars()
+
+        //when
+        var seminarList = listOf<CountSeminarResponse>()
+        val queryCount = hibernateQueryCounter.count {
+            seminarList = seminarController.getSeminarByQuery("", "earliest")
+        }.queryCount
+
+        //then
+        for (i in 0..seminarList.size - 2) {
+            assertThat(seminarRepository.findById(seminarList[i].id).get().createdAt)
+                .isBeforeOrEqualTo(seminarRepository.findById(seminarList[i + 1].id).get().createdAt)
+        }
+
+        //세미나 조회 쿼리 1
+        assertThat(queryCount).isEqualTo(1)
+    }
+
+    @Test
+    fun 키워드랑_오래된순으로_세미나_불러오기() {
+        //given
+        createSeminars()
+
+        //when
+        var seminarList = listOf<CountSeminarResponse>()
+        val queryCount = hibernateQueryCounter.count {
+            seminarList = seminarController.getSeminarByQuery("2", "earliest")
+        }.queryCount
+
+        //then
+        for (i in 0..seminarList.size - 2) {
+            assertThat(seminarRepository.findById(seminarList[i].id).get().createdAt)
+                .isBeforeOrEqualTo(seminarRepository.findById(seminarList[i + 1].id).get().createdAt)
+        }
+        for (seminar in seminarList) {
+            assertThat(seminar.name).contains("2")
+        }
+
+        //세미나 조회 쿼리1
+        assertThat(queryCount).isEqualTo(1)
+    }
+
+    @Test
+    fun 수강생_세미나_참여하기() {
+        //given
+        val participant = createParticipant("a@naver.com")
+        val instructor = createInstructor("b@naver.com")
+        val seminar = seminarService.makeSeminar(instructor, createSeminarMakeRequest("Spring"))
+        val joinSeminarRequest = JoinSeminarRequest("Participant")
+
+        //when
+        val queryCount = hibernateQueryCounter.count {
+            seminarController.joinSeminar(participant, joinSeminarRequest, seminar.id!!)
+        }.queryCount
+
+        //then
+        val seminarEntity = seminarRepository.findById(seminar.id!!).get()
+        val userSeminar = userSeminarRepository.findByUserEntityAndSeminar(participant, seminarEntity).get()
+        assertThat(userSeminar.role).isEqualTo(Role.Participant)
+
+        //유저, 세미나 조회 쿼리 2
+        //이미 참여중이거나 드랍했던 세미나인지 userSeminar 조회 쿼리 1
+        //세미나 업데이트 쿼리 1
+        //userSeminar 저장 쿼리 1
+        assertThat(queryCount).isEqualTo(5)
+    }
+
+    @Test
+    fun 진행자_세미나_진행하기() {
+        //given
+        val instructor = createInstructor("b@naver.com")
+        val seminarMaker = createInstructor("c@naver.com")
+        val seminar = seminarService.makeSeminar(seminarMaker, createSeminarMakeRequest("Spring"))
+        val joinSeminarRequest = JoinSeminarRequest("Instructor")
+
+        //when
+        val queryCount = hibernateQueryCounter.count {
+            seminarController.joinSeminar(instructor, joinSeminarRequest, seminar.id!!)
+        }.queryCount
+
+        //then
+        val seminarEntity = seminarRepository.findById(seminar.id!!).get()
+        val userSeminar = userSeminarRepository.findByUserEntityAndSeminar(instructor, seminarEntity).get()
+        assertThat(userSeminar.role).isEqualTo(Role.Instructor)
+
+        //유저, 세미나 조회 쿼리 2
+        //이미 참여중인지 userSeminar 조회 쿼리 1
+        //진행중인 다른 세미나가 있는지 userSeminar 조회 쿼리 1
+        //userSeminar 저장 쿼리 1
+        assertThat(queryCount).isEqualTo(5)
+    }
+
+    @Test
+    fun 세미나_드랍하기() {
+        //given
+        val participant = createParticipant("a@naver.com")
+        val instructor = createInstructor("b@naver.com")
+        val seminar = seminarService.makeSeminar(instructor, createSeminarMakeRequest("Spring"))
+        seminarService.joinSeminar(participant, "Participant", seminar.id!!)
+
+        //when
+        val queryCount = hibernateQueryCounter.count {
+            seminarController.dropSeminar(participant, seminar.id!!)
+        }.queryCount
+
+        //then
+        val seminarEntity = seminarRepository.findById(seminar.id!!).get()
+        val userSeminar = userSeminarRepository.findByUserEntityAndSeminar(participant, seminarEntity).get()
+        assertThat(userSeminar.isActive).isFalse
+        assertThat(userSeminar.droppedAt).isNotNull
+
+        //유저, 세미나, 유저세미나 조회 쿼리 3
+        //유저세미나, 세미나 업데이트 쿼리 2
+        assertThat(queryCount).isEqualTo(5)
+    }
+
+    private fun createInstructor(email: String): UserEntity {
+        val user = UserEntity(
+            "A", email, "1",
+            instructor = InstructorProfile("waffle", 5)
+        )
+        return userRepository.save(user)
+    }
+
+    private fun createParticipant(email: String): UserEntity {
+        val user = UserEntity(
+            "B", email, "2",
+            participant = ParticipantProfile("SNU", true)
+        )
+        return userRepository.save(user)
+    }
+
+    private fun createSeminarMakeRequest(name: String): SeminarMakeRequest {
+        return SeminarMakeRequest(name, 40, 5, "12:00")
+    }
+
+    private fun createSeminars(): List<SeminarResponse> {
+        val instructors = (1..20).map { createInstructor("ins@tructor#$it.com") }
+        return instructors.map { seminarService.makeSeminar(it, createSeminarMakeRequest("Spring${it.id}")) }
+    }
+}

--- a/seminar2/src/test/kotlin/com/wafflestudio/seminar/global/HibernateQueryCounter.kt
+++ b/seminar2/src/test/kotlin/com/wafflestudio/seminar/global/HibernateQueryCounter.kt
@@ -1,0 +1,73 @@
+package com.wafflestudio.seminar.global
+
+import org.hibernate.EmptyInterceptor
+import org.hibernate.cfg.AvailableSettings
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateProperties
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateSettings
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.orm.hibernate5.SpringBeanContainer
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean
+import javax.sql.DataSource
+
+interface HibernateQueryCounter {
+    fun <K> count(block: () -> K): Result<K>
+
+    data class Result<K>(
+        val value: K,
+        val queryCount: Int,
+    )
+}
+
+class HibernateQueryCounterImpl : EmptyInterceptor(), HibernateQueryCounter {
+    private val isCounting: ThreadLocal<Boolean> = ThreadLocal.withInitial { false }
+    private val queryCount: ThreadLocal<Int> = ThreadLocal.withInitial { 0 }
+
+    override fun onPrepareStatement(sql: String?): String {
+        if (isCounting.get()) {
+            queryCount.set(queryCount.get() + 1)
+        }
+
+        return super.onPrepareStatement(sql)
+    }
+
+    override fun <K> count(block: () -> K): HibernateQueryCounter.Result<K> {
+        isCounting.set(true)
+        queryCount.set(0)
+
+        val result = block()
+
+        isCounting.set(false)
+
+        return HibernateQueryCounter.Result(result, queryCount.get())
+    }
+}
+
+@Configuration
+class HibernateConfig {
+    @Bean
+    fun entityManagerFactory(
+        factory: EntityManagerFactoryBuilder,
+        dataSource: DataSource,
+        jpaProperties: JpaProperties,
+        hibernateProperties: HibernateProperties,
+        beanFactory: ConfigurableListableBeanFactory,
+        customInterceptor: HibernateQueryCounterImpl,
+    ): LocalContainerEntityManagerFactoryBean? {
+        val properties: Map<String, Any> =
+            hibernateProperties.determineHibernateProperties(jpaProperties.properties, HibernateSettings())
+                .also { it["hibernate.ejb.interceptor"] = customInterceptor }
+
+        return factory.dataSource(dataSource)
+            .packages("com.wafflestudio.seminar")
+            .properties(properties)
+            .build()
+            .also { it.jpaPropertyMap[AvailableSettings.BEAN_CONTAINER] = SpringBeanContainer(beanFactory) }
+    }
+
+    @Bean
+    fun customInterceptor() = HibernateQueryCounterImpl()
+}

--- a/seminar2/src/test/resources/application.yaml
+++ b/seminar2/src/test/resources/application.yaml
@@ -1,0 +1,9 @@
+spring:
+  profiles:
+    active: local
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
코드 잘 봤습니다! 컴포넌트들을 너무 잘 쪼개셔서 코드 리뷰하는데 편했어요.  나중에 제 코드 리팩토링 할때도 많이 도움될 것 같습니다. 세미나 API에 대해서 작성한 테스트 코드는 PR 확인해 보시면 됩니다!

- 엔티티 이름 뒤에 Entity 를 붙이거나 붙이지 않거나 통일하면 더 좋을 것 같아요
- authToken이 username으로 생성되는데 unique한 field 인 email로 생성되게 해야 할 것 같습니다.
- SeminarMakeRequest의 field: Notnull message를 이용하려면 필드를 nullable하게 바꾸는 방법이 있습니다(String -> String?) 그런데 null이면 안되는 필드를 일부러 nullable하게 바꾸는 것이 살짝 모순?이 있어서 좋은 방법인지는 모르겠어요
- editSeminar에서 로그인 된 유저가 진행중인 세미나를 수정하게끔 되어있는데 여러 명이 세미나를 함께 진행할 수 있어서 실제 세미나를 만든 유저가 맞는지 확인하는 로직이 필요해 보입니다.
- 세미나를 수정할 때 모든 필드를 요구하는 것보다 부분적으로 수정할 수 있게끔 하는 것이 좋을 것 같습니다 그리고 editSeminarRequest에 time 필드가 생략되었어요
- 세미나 만들기를 제외한 모든 API에서 N+1 문제가 발생하는 것으로 보입니다. fetch join과 querydsl을 이용하여 쿼리 수 최적화를 해주면 좋을 것 같아요. 테스트 코드에 최적화 후 예상되는 쿼리 수를 적어보았는데 실제로 최적화를 해본 것이 아니라 예상이 틀릴 수도 있는 점 감안해주시면 좋을 것 같아요
